### PR TITLE
Add max description and summary values to the DOM so we can validate

### DIFF
--- a/lib/modules/idea-form-widgets/public/js/main.js
+++ b/lib/modules/idea-form-widgets/public/js/main.js
@@ -85,8 +85,14 @@ if (fieldsetElement) {
   var pondEl = document.querySelector('.filepond--root');
 }
 
+var maxDescription, maxSummary;
+
 $(document).ready(function () {
-  var ideaForm = document.getElementById('js-form');
+    
+    maxSummary = $('#maxSummary').length ? $('#maxSummary').val() || 5000 : 5000;
+    maxDescription = $('#maxDescription').length ? $('#maxDescription').val() || 5000 : 5000;
+    
+    var ideaForm = document.getElementById('js-form');
 
 
 /*  if (ideaFiles) {
@@ -135,11 +141,12 @@ $(document).ready(function () {
        },
        summary : {
          minlength: 20,
-         maxlength: 140,
+         maxlength: maxSummary,
        },
         description : {
           required: true,
-          minlength: 140
+          minlength: 140,
+          maxLength: maxDescription
         },
         validateImages: {
           validateFilePond: true
@@ -227,7 +234,6 @@ $(document).ready(function () {
 
 // Summary
 // -------
-var maxLen    = 140;
 var textarea  = document.querySelector('textarea[name="summary"]');
 var charsLeft = document.querySelector('#charsLeft span');
 
@@ -238,7 +244,7 @@ if (textarea && charsLeft) {
     var key = event.key.toLowerCase();
 
     // Prevent input when maximum is reached.
-      if( len == maxLen ) {
+      if( len == maxSummary ) {
         switch( key ) {
           case 'delete': case 'backspace':
           case 'arrowdown': case 'arrowup':
@@ -252,8 +258,8 @@ if (textarea && charsLeft) {
   textarea.addEventListener('keyup', updateCharsLeft);
 
   function updateCharsLeft() {
-    charsLeft.innerHTML = maxLen - textarea.value.length;
-    if (maxLen >= textarea.value.length) {
+    charsLeft.innerHTML = maxSummary - textarea.value.length;
+    if (maxSummary >= textarea.value.length) {
       charsLeft.style.color = '#9A9A9A';
     } else {
       charsLeft.style.color = 'red';

--- a/lib/modules/idea-form-widgets/views/widget.html
+++ b/lib/modules/idea-form-widgets/views/widget.html
@@ -81,6 +81,7 @@
 							{% endif %}
 
 							<div id="charsLeft">Je hebt nog <span>{{data.widget.maxSummary}}</span> tekens over.</div>
+							<input type="hidden" id="maxSummary" value="{{ data.widget.maxSummary }}" />
 						</div>
 					</div>
 
@@ -163,6 +164,7 @@
 					<input class="idea-form-redirect-uri" type="hidden" name="redirect" value="{{data.widget.redirect}}" />
 
 					<div id="charsLeftMain">Nog minimaal <span>{{data.widget.maxDescription}}</span> tekens.</div><br/><br/>
+					<input type="hidden" id="maxDescription" value="{{ data.widget.maxDescription }}" />
 
 					{% if idea.id %}
 					<input type="hidden" name="id" value="{{idea.id}}" />


### PR DESCRIPTION
The max description and summary values were not used in the widget itself, it was always defaulting to 140. With this fix these values will be inserted into the DOM in hidden fields, and retrieved upon validation of the form.

This setup is still not perfect, because we also define these validation limits in the API. If these numbers differ we will get strange errors (especially when the API is stricter).