### PR TITLE
Add option to set a flag color per theme in the global settings

### DIFF
--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -23,6 +23,49 @@ const rightsChoices =  [
   }
 ]
 
+const flagChoices = [
+  {
+    label: 'Groen',
+    value: 'green'
+  },
+  {
+    label: 'Donkergroen',
+    value: 'dark-green'
+  },
+  {
+    label: 'Grijs',
+    value: 'gray'
+  },
+  {
+    label: 'Donkergrijs',
+    value: 'dark-gray'
+  },
+  {
+    label: 'Geel',
+    value: 'yellow'
+  },
+  {
+    label: 'Blauw',
+    value: 'blue'
+  },
+  {
+    label: 'Donkerblauw',
+    value: 'dark-blue'
+  },
+  {
+    label: 'Rood',
+    value: 'red'
+  },
+  {
+    label: 'Donkerrood',
+    value: 'dark-red'
+  },
+  {
+    label: 'Paars',
+    value: 'purple'
+  },
+];
+
 
 function unauthorized(req, res) {
     var challengeString = 'Basic realm=Openstad';
@@ -159,6 +202,13 @@ module.exports = {
           type: 'text',
           label: 'Name',
           type: 'string',
+        },
+        {
+          name: 'flag',
+          type: 'select',
+          label: 'Welke vlag moet er getoond worden bij dit thema?',
+          choices: flagChoices,
+          def: 'blue'
         }
       ]
     },

--- a/lib/modules/openlayer-map-widgets/views/widget.html
+++ b/lib/modules/openlayer-map-widgets/views/widget.html
@@ -112,15 +112,25 @@
     {% if (idea.location) and (idea.status != 'DENIED' or ideas.length == 1) %}
     {% if (idea.location.coordinates[0]) and (idea.location.coordinates[1]) %}
 
-    var markerColorMapping = {
-        'DONE': '/img/idea/flag-blue.svg',
-        'ACCEPTED': '/img/idea/flag-blue.svg',
-        'BUSY': '/img/idea/flag-blue.svg',
-        'CLOSED': '/img/idea/flag-gray.svg',
-        'DENIED': '/img/idea/flag-gray.svg'
-    };
+    var themes = {{ data.global.themes | json }};
+    var flag = '/img/idea/flag-blue.svg';
 
-    var markerUrl = markerColorMapping['{{idea.status}}'] || '/img/idea/flag-blue.svg';
+    if ('{{idea.status}}' == 'CLOSED' || '{{idea.status}}' == 'DENIED') {
+        flag = '/img/idea/flag-gray.svg';
+    } else {
+        if (themes && themes.length > 0) {
+            var selectedTheme = themes.filter(function (theme) {
+                // todo: Can we match this in another way besides theme name?
+                return theme.value == '{{ idea.extraData.theme }}';
+            });
+
+            if (selectedTheme && selectedTheme.length == 1) {
+                flag = '/img/idea/flag-' + selectedTheme[0].flag + '.svg';
+            }
+        }
+    }
+
+    var markerUrl = flag || '/img/idea/flag-blue.svg';
 
     var marker = new ol.Feature({
         geometry: new ol.geom.Point(

--- a/public/img/idea/flag-dark-blue.svg
+++ b/public/img/idea/flag-dark-blue.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="25" viewBox="0 0 22 25">
+    <g fill="none" fill-rule="nonzero">
+        <ellipse cx="4.34" cy="22.84" fill="#B6B8BA" rx="4.34" ry="1.39"/>
+        <path fill="#008dcf" d="M5.63 22.84H2.96V0h18.95l-6.85 6.85 6.75 6.76H5.67z"/>
+    </g>
+</svg>

--- a/public/img/idea/flag-dark-gray.svg
+++ b/public/img/idea/flag-dark-gray.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="25" viewBox="0 0 22 25">
+    <g fill="none" fill-rule="nonzero">
+        <ellipse cx="4.34" cy="22.84" fill="#B6B8BA" rx="4.34" ry="1.39"/>
+        <path fill="#949494" d="M5.63 22.84H2.96V0h18.95l-6.85 6.85 6.75 6.76H5.67z"/>
+    </g>
+</svg>

--- a/public/img/idea/flag-dark-green.svg
+++ b/public/img/idea/flag-dark-green.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="22px" height="25px" viewBox="0 0 22 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+    <title>icon/flag</title>
+    <desc>Created with Sketch.</desc>
+    <g id="icon/flag" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="kaart-vlaggetje" fill-rule="nonzero">
+            <ellipse id="Oval" fill="#B6B8BA" cx="4.34" cy="22.84" rx="4.34" ry="1.39"/>
+            <polygon id="Shape" fill="#008941" points="5.63 22.84 2.96 22.84 2.96 0 21.91 0 15.06 6.85 21.81 13.61 5.67 13.61"/>
+        </g>
+    </g>
+</svg>

--- a/public/img/idea/flag-dark-red.svg
+++ b/public/img/idea/flag-dark-red.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="25" viewBox="0 0 22 25">
+    <g fill="none" fill-rule="nonzero">
+        <ellipse cx="4.34" cy="22.84" fill="#B6B8BA" rx="4.34" ry="1.39"/>
+        <path fill="#e41e25" d="M5.63 22.84H2.96V0h18.95l-6.85 6.85 6.75 6.76H5.67z"/>
+    </g>
+</svg>

--- a/public/img/idea/flag-purple.svg
+++ b/public/img/idea/flag-purple.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="25" viewBox="0 0 22 25">
+    <g fill="none" fill-rule="nonzero">
+        <ellipse cx="4.34" cy="22.84" fill="#B6B8BA" rx="4.34" ry="1.39"/>
+        <path fill="#a94893" d="M5.63 22.84H2.96V0h18.95l-6.85 6.85 6.75 6.76H5.67z"/>
+    </g>
+</svg>

--- a/public/img/idea/flag-red.svg
+++ b/public/img/idea/flag-red.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="25" viewBox="0 0 22 25">
+    <g fill="none" fill-rule="nonzero">
+        <ellipse cx="4.34" cy="22.84" fill="#B6B8BA" rx="4.34" ry="1.39"/>
+        <path fill="#f18a18" d="M5.63 22.84H2.96V0h18.95l-6.85 6.85 6.75 6.76H5.67z"/>
+    </g>
+</svg>

--- a/public/img/idea/flag-yellow.svg
+++ b/public/img/idea/flag-yellow.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="25" viewBox="0 0 22 25">
+    <g fill="none" fill-rule="nonzero">
+        <ellipse cx="4.34" cy="22.84" fill="#B6B8BA" rx="4.34" ry="1.39"/>
+        <path fill="#efc215" d="M5.63 22.84H2.96V0h18.95l-6.85 6.85 6.75 6.76H5.67z"/>
+    </g>
+</svg>


### PR DESCRIPTION
This flag will be added into the openlayer map based on the theme of the
idea.
This commit also adds some extra colours as requested by The Hague.