### PR TITLE
Add handler for vote limiter coming from oauth

### DIFF
--- a/lib/modules/idea-single-widgets/index.js
+++ b/lib/modules/idea-single-widgets/index.js
@@ -101,7 +101,16 @@ module.exports = {
         })
         .catch(function (err) {
             console.log('===> voting err', err);
-            res.status(500).json(err);
+            
+            let referer = req.header('Referer');
+            let appUrl = req.data.global.siteConfig.cms.url;
+            
+            // todo: redirect to the plan - where do we get the ideaId from?
+            if (referer && referer.indexOf(appUrl) === -1) {
+                res.redirect(appUrl);
+            } else {
+                res.status(500).json(err);
+            }
          });
      }
 


### PR DESCRIPTION
We would be shown a JSON error before, but now we redirect to the app.
We still have to redirect to the correct plan, but at least now we don't
show the JSON error to the user-facing side.