### PR TITLE
Add option to hide last name with arguments / reactions

### DIFF
--- a/lib/modules/arguments-widgets/index.js
+++ b/lib/modules/arguments-widgets/index.js
@@ -63,6 +63,46 @@ module.exports = {
         },
       ]
     },
+    {
+      name: 'showLastNameForArguments',
+      type: 'select',
+      label: 'Show last name for arguments?',
+      choices: [
+        {
+          label: 'Yes',
+          value: 'yes'
+        },
+        {
+          label: 'No, only for administrators',
+          value: 'adminonly'
+        },
+        {
+          label: 'No',
+          value: 'no'
+        }
+      ],
+      def: 'yes'
+    },
+    {
+      name: 'showLastNameForReactions',
+      type: 'select',
+      label: 'Show last name for reactions?',
+      choices: [
+        {
+          label: 'Yes',
+          value: 'yes'
+        },
+        {
+          label: 'No, only for administrators',
+          value: 'adminonly'
+        },
+        {
+          label: 'No',
+          value: 'no'
+        }
+      ],
+      def: 'yes'
+    },
   ],
   construct: function(self, options) {
      const superPushAssets = self.pushAssets;

--- a/lib/modules/arguments-widgets/index.js
+++ b/lib/modules/arguments-widgets/index.js
@@ -3,6 +3,7 @@ const rp = require('request-promise');
 module.exports = {
   extend: 'apostrophe-widgets',
   label: 'Arguments',
+  alias: 'arguments',
   addFields: [
     {
       name: 'ideaId',
@@ -119,5 +120,19 @@ module.exports = {
        return superOutput(widget, options);
   //     return result;
      };
-   }
+     
+     self.addHelpers({
+        showLastName: function (type, widget, user) {
+            if (type == 'reactions' && (widget.showLastNameForReactions == 'yes' || (widget.showLastNameForReactions == 'adminonly' && user.role == 'admin'))) {
+                return user.lastName;
+            } else if (type == 'arguments' && (widget.showLastNameForArguments == 'yes' || (widget.showLastNameForArguments == 'adminonly' && user.role == 'admin'))) {
+                return user.lastName;
+            }
+            
+            return '';
+        }
+     });
+   },
+   
+   
 };

--- a/lib/modules/arguments-widgets/views/argument.html
+++ b/lib/modules/arguments-widgets/views/argument.html
@@ -2,9 +2,7 @@
   <div class="user ">
 
       <strong>{{arg.user.firstName}}
-        {% if data.widget.showLastNameForArguments == 'yes' or (data.widget.showLastNameForArguments == 'adminonly' and arg.user.role == 'admin') %}
-        {{arg.user.lastName}}
-        {% endif %}
+        {{ apos.arguments.showLastName('arguments', data.widget, arg.user) }}
       </strong> | {{ arg.createdAt | date('LLL') }}
 
     {% if mayEdit %}

--- a/lib/modules/arguments-widgets/views/argument.html
+++ b/lib/modules/arguments-widgets/views/argument.html
@@ -1,6 +1,12 @@
 <div class="argument argument-variant-{{arg.label}} argument-action-form " data-id="{{arg.id}}" id="arg{{arg.id}}">
   <div class="user ">
-    <strong>{{arg.user.firstName}} {{arg.user.lastName}}</strong> | {{ arg.createdAt | date('LLL') }}
+
+      <strong>{{arg.user.firstName}}
+        {% if data.widget.showLastNameForArguments == 'yes' or (data.widget.showLastNameForArguments == 'adminonly' and arg.user.role == 'admin') %}
+        {{arg.user.lastName}}
+        {% endif %}
+      </strong> | {{ arg.createdAt | date('LLL') }}
+
     {% if mayEdit %}
     <a href="#" type="submit" class="default edit" value="bewerken" title="Argument bewerken">&nbsp;</a>
     {% endif %}

--- a/lib/modules/arguments-widgets/views/reaction.html
+++ b/lib/modules/arguments-widgets/views/reaction.html
@@ -1,9 +1,7 @@
 <div class="reaction argument-variant-{{arg.label}}" id="arg{{reaction.id}}">
   <div class="user {{'admin' if  data.isAdmin}}">
     <strong>{{reaction.user.firstName}}
-      {% if data.widget.showLastNameForReactions == 'yes' or (data.widget.showLastNameForReactions == 'adminonly' and reaction.user.role == 'admin') %}
-        {{reaction.user.lastName}}
-      {% endif %}
+      {{ apos.arguments.showLastName('reactions', data.widget, reaction.user) }}
     </strong> | {{reaction.createdAt | date('LLL')}}
 
     {% if mayEdit %}

--- a/lib/modules/arguments-widgets/views/reaction.html
+++ b/lib/modules/arguments-widgets/views/reaction.html
@@ -1,6 +1,10 @@
 <div class="reaction argument-variant-{{arg.label}}" id="arg{{reaction.id}}">
   <div class="user {{'admin' if  data.isAdmin}}">
-    <strong>{{reaction.user.firstName}} {{reaction.user.lastName}}</strong> | {{reaction.createdAt | date('LLL')}}
+    <strong>{{reaction.user.firstName}}
+      {% if data.widget.showLastNameForReactions == 'yes' or (data.widget.showLastNameForReactions == 'adminonly' and reaction.user.role == 'admin') %}
+        {{reaction.user.lastName}}
+      {% endif %}
+    </strong> | {{reaction.createdAt | date('LLL')}}
 
     {% if mayEdit %}
     <a href="#" type="submit" class="default edit" value="bewerken" title="Argument bewerken">&nbsp;</a>


### PR DESCRIPTION
Voor zowel argumenten als reacties is er een optie bijgekomen om de
achternaam wel / niet te tonen. Er is ook de optie om de achternaam
alleen te tonen bij administrators.

Standaard staat deze optie aan, waardoor de huidige functionaliteit
nagebootst wordt; De achternaam wordt altijd getoond.