### PR TITLE
Add check for 'hideOriginalIdeaLink' in extraData to show original link

### DIFF
--- a/lib/modules/begroot-widgets/index.js
+++ b/lib/modules/begroot-widgets/index.js
@@ -183,6 +183,16 @@ module.exports = {
      const superLoad = self.load;
 
      self.load = function (req, widgets, callback) {
+       req.data.ideas = req.data.ideas.map((idea) => {
+         idea.showOriginalIdeaLink = true;
+         
+         if (idea.extraData.hideOriginalIdeaLink) {
+           idea.showOriginalIdeaLink = false;
+         }
+         
+         return idea;
+       });
+       
     /*    const acceptedIdeas = req.data.ideas ? req.data.ideas.filter(idea => idea.status === 'ACCEPTED') : []; */
         widgets.forEach((widget) => {
           widget.acceptedIdeas = req.data.ideas;

--- a/lib/modules/begroot-widgets/index.js
+++ b/lib/modules/begroot-widgets/index.js
@@ -183,16 +183,6 @@ module.exports = {
      const superLoad = self.load;
 
      self.load = function (req, widgets, callback) {
-       req.data.ideas = req.data.ideas.map((idea) => {
-         idea.showOriginalIdeaLink = true;
-         
-         if (idea.extraData.hideOriginalIdeaLink) {
-           idea.showOriginalIdeaLink = false;
-         }
-         
-         return idea;
-       });
-       
     /*    const acceptedIdeas = req.data.ideas ? req.data.ideas.filter(idea => idea.status === 'ACCEPTED') : []; */
         widgets.forEach((widget) => {
           widget.acceptedIdeas = req.data.ideas;

--- a/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
@@ -141,7 +141,7 @@
 					</table>
 					{% endif %}
 					<br />
-					{% if data.widget.originalIdeaUrl and idea.showOriginalIdeaLink %}
+					{% if data.widget.originalIdeaUrl and !idea.extraData.hideOriginalLink %}
 					{% set originalId = idea.extraData.originalId if idea.extraData.originalId else idea.id %}
 					<div class="margin-hor-10">
 						<a href="{{data.widget.originalIdeaUrl}}/{{originalId}}" class="link-original link-caret--blue" target="_blank">Bekijk het originele voorstel</a>

--- a/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
@@ -141,7 +141,7 @@
 					</table>
 					{% endif %}
 					<br />
-					{% if data.widget.originalIdeaUrl %}
+					{% if data.widget.originalIdeaUrl and idea.showOriginalIdeaLink %}
 					{% set originalId = idea.extraData.originalId if idea.extraData.originalId else idea.id %}
 					<div class="margin-hor-10">
 						<a href="{{data.widget.originalIdeaUrl}}/{{originalId}}" class="link-original link-caret--blue" target="_blank">Bekijk het originele voorstel</a>


### PR DESCRIPTION
If the 'hideOriginalIdeaLink' is found in the extraData and is true, the
original plan link won't be shown.

Related ticket: https://trello.com/c/AmSGXWOG/609-mogelijkheid-tot-weghalen-bekijk-originele-voorstel