### PR TITLE
Allow HTML to be entered into the thank you message for budgeting

### DIFF
--- a/lib/modules/begroot-widgets/views/phase-voting/budgeting.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/budgeting.html
@@ -260,7 +260,7 @@
 							<div class="checkmark-block-green">
 								<h4>Gelukt, je hebt gestemd!</h4>
 								<br/>
-								{{data.widget.thankyou_message}}
+								{{data.widget.thankyou_message | safe}}
 								{% if data.widget.showNewsletterButton and data.widget.showNewsletterButton == 'yes' %}
 								<br />
 								<br />


### PR DESCRIPTION
Related ticket: https://trello.com/c/FjKxefHL/610-html-toestaan-in-thank-you-message-bij-begroten