### PR TITLE
Fix idea count and allow user to enter fixed idea count in header widget

### DIFF
--- a/lib/modules/header-widgets/index.js
+++ b/lib/modules/header-widgets/index.js
@@ -117,6 +117,30 @@ module.exports = {
             type: 'boolean',
             label: 'Open in new window',
             def: false
+        },
+        {
+            name: 'hasFixedIdeaCount',
+            type: 'boolean',
+            label: 'Idea count is fixed',
+            def: false,
+            choices: [
+                {
+                    value: true,
+                    label: "Yes",
+                    showFields: [
+                        'fixedIdeaCount'
+                    ]
+                },
+                {
+                    value: false,
+                    label: "No"
+                },
+            ]
+        },
+        {
+            name: 'fixedIdeaCount',
+            label: 'Fixed idea count (max 3 digits)',
+            type: 'string'
         }
     ],
 
@@ -128,6 +152,18 @@ module.exports = {
                     const imageId = styleSchema.generateId();
                     widget.imageId = imageId;
                     widget.formattedImageStyles = styleSchema.format(imageId, widget.imageStyles);
+                }
+                
+                if (widget.hasFixedIdeaCount) {
+                    widget.ideaCountParts = widget.fixedIdeaCount ? widget.fixedIdeaCount.substring(0, 3).split("") : [];
+                } else {
+                    widget.ideaCountParts = req.data.ideas ? req.data.ideas.length.toString().split("") : 0;
+                }
+                
+                if (widget.ideaCountParts.length < 3) {
+                    while (widget.ideaCountParts.length < 3) {
+                        widget.ideaCountParts = [0, ...widget.ideaCountParts];
+                    }
                 }
             });
             return superLoad(req, widgets, callback);

--- a/lib/modules/header-widgets/index.js
+++ b/lib/modules/header-widgets/index.js
@@ -154,16 +154,18 @@ module.exports = {
                     widget.formattedImageStyles = styleSchema.format(imageId, widget.imageStyles);
                 }
                 
+                // Transform the (fixed) idea count to a an array
                 if (widget.hasFixedIdeaCount) {
                     widget.ideaCountParts = widget.fixedIdeaCount ? widget.fixedIdeaCount.substring(0, 3).split("") : [];
                 } else {
-                    widget.ideaCountParts = req.data.ideas ? req.data.ideas.length.toString().split("") : 0;
+                    widget.ideaCountParts = req.data.ideas ? req.data.ideas.length.toString().split("") : [];
                 }
                 
-                if (widget.ideaCountParts.length < 3) {
-                    while (widget.ideaCountParts.length < 3) {
-                        widget.ideaCountParts = [0, ...widget.ideaCountParts];
-                    }
+                // Prepend the idea count with zeroes to get a length of 3
+                // Note: it is possible that we have a length of 4 when there are more than 1000 ideas
+                //       the likelihood of this happening is very low, so we can avoid checking that for now.
+                while (widget.ideaCountParts.length < 3) {
+                    widget.ideaCountParts = [0, ...widget.ideaCountParts];
                 }
             });
             return superLoad(req, widgets, callback);

--- a/lib/modules/header-widgets/views/widget.html
+++ b/lib/modules/header-widgets/views/widget.html
@@ -30,9 +30,9 @@
                     <a href="/plannen" class="margin-bottom-xs scroll-link block no-decoration">
                         <span class="box-blue block">
                             <span class="margin-right-s">
-                              <span class="number-plate"> 0 </span>
-                              <span class="number-plate"> 2 </span>
-                              <span class="number-plate"> 3 </span>
+                                {% for num in data.widget.ideaCountParts %}
+                                    <span class="number-plate"> {{num}} </span>
+                                {% endfor %}
                             </span>
                             plannen
                         </span>


### PR DESCRIPTION
The idea count in the header widget is now retrieved from the actual
ideas.

There is now a new option to enter a fixed amount of ideas. Only the
first 3 digits entered are used. If the length is less than 3 the amount
is prepended with zeros.

Note: There is no validation currently, so it is allowed to enter text.

Related ticket: https://trello.com/c/njwdWDLA/611-een-vast-aantal-plannen-kunnen-invullen-in-de-header-widget