### PR TITLE
Add fields to the begroot widget to show newsletter button

### DIFF
--- a/lib/modules/begroot-widgets/index.js
+++ b/lib/modules/begroot-widgets/index.js
@@ -160,6 +160,28 @@ const fields = [
     textarea: true,
     def: 'Bedankt voor het stemmen! De stemperiode loopt van 9 september t/m 6 oktober 2019. Wil je weten welke plannen het vaakst zijn gekozen en uitgevoerd worden? De uitslag wordt op 15 oktober 2019 gepubliceerd op centrumbegroot.amsterdam.nl.'
   },
+  {
+    name:    'showNewsletterButton',
+    label:   'Show newsletter button after voting?',
+    type:    'select',
+    choices: [
+      {
+        label: 'No',
+        value: 'no'
+      },
+      {
+        label:      'Yes',
+        value:      'yes',
+        showFields: ['newsletterButtonText']
+      }
+    ],
+    def:     'no'
+  },
+  {
+    name: 'newsletterButtonText',
+    label: 'Text on the newsletter button',
+    type: 'string'
+  },
 ].concat(
     ideaStates.map((state) => {
       return {


### PR DESCRIPTION
After voting in the begroot widget this will show a button to subscribe
to the newsletter.

These changes were once merged into development but lost in later commits.

Related ticket: https://trello.com/c/HuOjuDOF/589-nieuwsbrief-inschrijven-knop-tonen-na-versturen-budget-stem-fase-2