### PR TITLE
Add option to allow anonymous votes in budgeting

### DIFF
--- a/lib/modules/begroot-widgets/index.js
+++ b/lib/modules/begroot-widgets/index.js
@@ -24,6 +24,12 @@ const fields = [
     ]
   },
   {
+    name: 'allowAnonymousVotes',
+    type: 'boolean',
+    def: false,
+    label: 'Allow anonymous users to vote'
+  },
+  {
     name: 'showVoteCount',
     label: 'Show vote count?',
     type: 'boolean',

--- a/lib/modules/begroot-widgets/views/phase-voting/index.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/index.html
@@ -17,7 +17,11 @@
 
 	<script>
 	 var userHasVoted = {{data.widget.userHasVoted}};
-	 var userIsLoggedIn = {{true if data.loggedIn else false}};
+	 {% if data.widget.allowAnonymousVotes %}
+	   var userIsLoggedIn = {{true if (data.loggedIn or (data.openstadUser and data.openstadUser.role == 'anonymous')) else false}};
+	 {% else %}
+	   var userIsLoggedIn = {{true if data.loggedIn else false}};
+	 {% endif %}
 	 var authServerLogoutUrl = '{{authServerLogoutUrl}}';
 	 var defaultSort = 'random'; //	{% if config.budgeting.isActive %}'random'{% else %}'ranking'{% endif %}
 	 var siteId = '{{data.global.siteId}}';


### PR DESCRIPTION
This is due to the fact that the Hague uses a uniqueCode oauth client, without any required fields. When the user returns from the uniqueCode login route, he/she is logged in, but anonymously. This option allows these users to vote.

Related ticket: https://trello.com/c/7YcqoCrM/648-begroten-widget-mogelijkheid-geven-om-anonieme-gebruikers-te-laten-stemmen