### PR TITLE
Allow forcing of a specific language through env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,10 @@ apos.define('idea-single-widgets', {
     }
 });
 ```
+
+## Forcing a language
+It's possible to force the application into a specific language by specifying the locale as the `FORCE_LANGUAGE` in the .env file.
+To force the dutch language for example:
+```
+FORCE_LANGUAGE=nl
+```

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -281,10 +281,19 @@ module.exports = {
       siteConfig.modules['apostrophe-workflow-modified-documents'] = {};
 
     } else {
+      
+      let locales = ['nl', 'en'];
+      let defaultLocale = 'nl';
+      
+      if (process.env.FORCE_LANGUAGE) {
+        locales = [process.env.FORCE_LANGUAGE];
+        defaultLocale = process.env.FORCE_LANGUAGE;
+      }
+      
       siteConfig.modules['apostrophe-i18n'] = {
-        locales: ['nl', 'en'],
+        locales,
         directory: __dirname + '/locales',
-        defaultLocale: 'nl'
+        defaultLocale
       }
     }
 

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -282,12 +282,12 @@ module.exports = {
 
     } else {
       
-      let locales = ['nl', 'en'];
-      let defaultLocale = 'nl';
-      
       if (process.env.FORCE_LANGUAGE) {
-        locales = [process.env.FORCE_LANGUAGE];
-        defaultLocale = process.env.FORCE_LANGUAGE;
+        const locales = [process.env.FORCE_LANGUAGE];
+        const defaultLocale = process.env.FORCE_LANGUAGE;
+      } else {
+        const locales = ['nl', 'en'];
+        const defaultLocale = 'nl';
       }
       
       siteConfig.modules['apostrophe-i18n'] = {


### PR DESCRIPTION
Use the FORCE_LANGUAGE key in the env file to force a specific language, e.g. FORCE_LANGUAGE=nl

Related ticket: https://trello.com/c/jUTokk7r/649-vertalingen-mogelijkheid-om-%C3%A9%C3%A9n-taal-te-forceren